### PR TITLE
Clarify installation on Gnome with Wayland

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This extension brings you the data from the ICE portal directly to your status b
 git clone https://github.com/mauricemeyer/gnome-shell-ice-portal.git ~/.local/share/gnome-shell/extensions/db-ice-portal@mor.re
 ```
 
-Then restart your GNOME with `Alt + F2`, in the opening menu type `r` and press enter.
+Then restart your GNOME with `Alt + F2`, in the opening menu type `r` and press enter. If you use Wayland, you have to logout/login or restart your PC.
 
 After that, open the GNOME Tweaks tool and under extensions, enable the extension.
 


### PR DESCRIPTION
Gnome running with Wayland doesn't allow restarts.

See https://mail.gnome.org/archives/commits-list/2015-March/msg01019.html